### PR TITLE
Improve performance and add performance tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ import com.noahbres.meepmeep.core.colorscheme.scheme.ColorSchemeRedDark;
 
 public class MeepMeepTesting {
     public static void main(String[] args) {
+        // TODO: If you experience poor performance, enable this flag
+        // System.setProperty("sun.java2d.opengl", "true");
+
         // Declare a MeepMeep instance
         // With a field size of 800 pixels
         MeepMeep mm = new MeepMeep(800)
@@ -59,3 +62,6 @@ public class MeepMeepTesting {
     }
 }
 ```
+
+## Poor Performance?
+On some systems hardware acceleration may not be enabled by default where it could be used. To enable hardware acceleration use the cli flag: `-Dsun.java2d.opengl=true` or enable it _before_ initializing your `MeepMeep` instance with `System.setProperty("sun.java2d.opengl", "true");`.

--- a/src/main/kotlin/com/noahbres/meepmeep/MeepMeep.kt
+++ b/src/main/kotlin/com/noahbres/meepmeep/MeepMeep.kt
@@ -94,6 +94,7 @@ open class MeepMeep(private val windowSize: Int) {
 
         g.dispose()
         canvas.bufferStrat.show()
+        Toolkit.getDefaultToolkit().sync()
     }
 
     private val update: (deltaTime: Long) -> Unit = { deltaTime ->

--- a/src/main/kotlin/com/noahbres/meepmeep/MeepMeep.kt
+++ b/src/main/kotlin/com/noahbres/meepmeep/MeepMeep.kt
@@ -20,7 +20,7 @@ import javax.imageio.ImageIO
 import javax.swing.*
 import javax.swing.border.EtchedBorder
 
-open class MeepMeep(private val windowSize: Int) {
+open class MeepMeep(private val windowSize: Int, fps: Int = 60) {
     companion object {
         // Default entities
         @JvmStatic
@@ -90,7 +90,7 @@ open class MeepMeep(private val windowSize: Int) {
         val fpsFont = Font("Sans", Font.BOLD, 20)
         g.font = fpsFont
         g.color = ColorManager.COLOR_PALETTE.GREEN_600
-        g.drawString("${loopManager.fps} FPS", 10, 20)
+        g.drawString(String.format("%.1f FPS", loopManager.fps), 10, 20)
 
         g.dispose()
         canvas.bufferStrat.show()
@@ -117,7 +117,7 @@ open class MeepMeep(private val windowSize: Int) {
         }
     }
 
-    private val loopManager = LoopManager(120, update, render)
+    private val loopManager = LoopManager(fps, update, render)
 
     // Road Runner UI Elements
     val sliderPanel = JPanel()
@@ -217,7 +217,7 @@ open class MeepMeep(private val windowSize: Int) {
 
         onCanvasResize()
 
-        Thread(loopManager).start()
+        loopManager.start()
 
         // Road Runner Start
 //        removeEntity(DEFAULT_BOT_ENTITY)

--- a/src/main/kotlin/com/noahbres/meepmeep/core/entity/BotEntity.kt
+++ b/src/main/kotlin/com/noahbres/meepmeep/core/entity/BotEntity.kt
@@ -44,8 +44,7 @@ open class BotEntity(
     }
 
     override fun update(deltaTime: Long) {
-
-        pose = Pose2d(pose.x, pose.y, pose.heading + Math.toRadians(0.1 * deltaTime))
+        pose = Pose2d(pose.x, pose.y, pose.heading + Math.toRadians(0.1 * deltaTime / 1000.0 / 1000.0))
     }
 
     override fun render(gfx: Graphics2D, canvasWidth: Int, canvasHeight: Int) {

--- a/src/main/kotlin/com/noahbres/meepmeep/roadrunner/entity/RoadRunnerBotEntity.kt
+++ b/src/main/kotlin/com/noahbres/meepmeep/roadrunner/entity/RoadRunnerBotEntity.kt
@@ -74,7 +74,7 @@ class RoadRunnerBotEntity(
 
         if (skippedLoops++ < SKIP_LOOPS) return
 
-        if (!trajectoryPaused) trajectorySequenceElapsedTime += deltaTime / 1000.0
+        if (!trajectoryPaused) trajectorySequenceElapsedTime += deltaTime / 1000.0 / 1000.0 / 1000.0
 
         when {
             trajectorySequenceElapsedTime <= currentTrajectorySequence!!.duration -> {


### PR DESCRIPTION
This uses `Executors.newSingleThreadScheduledExecutor` to schedule the drawing loop (which is more accurate than the previous method) and changes `deltaTime` to be in nanoseconds for a smoother experience. Additionally, hardware acceleration wasn't enabled by default on my system, so I added documentation about a flag to enable it.