### PR TITLE
Customizable mouse coordinate display location

### DIFF
--- a/src/main/kotlin/com/noahbres/meepmeep/MeepMeep.kt
+++ b/src/main/kotlin/com/noahbres/meepmeep/MeepMeep.kt
@@ -47,6 +47,14 @@ open class MeepMeep @JvmOverloads constructor(private val windowX: Int, private 
     private val requestedAddEntityList = mutableListOf<Entity>()
     private val requestedRemoveEntityList = mutableListOf<Entity>()
 
+    // Controls the x and y position of the display for the mouse coordinates
+    private var mouseCoordinateDisplayX = 10
+    private var mouseCoordinateDisplayY = canvas.height - 8
+
+    // Publicly accessible canvas width & height
+    val canvasWidth = canvas.width
+    val canvasHeight = canvas.height
+
     private val zIndexManager = ZIndexManager();
 
     // TODO: Make custom dirty list that auto sorts
@@ -96,7 +104,7 @@ open class MeepMeep @JvmOverloads constructor(private val windowX: Int, private 
             "(%.1f, %.1f)".format(
                 mouseToFieldCoords.x,
                 mouseToFieldCoords.y,
-            ), 10, canvas.height - 8
+            ), mouseCoordinateDisplayX, mouseCoordinateDisplayY
         )
 
         g.dispose()
@@ -366,6 +374,11 @@ open class MeepMeep @JvmOverloads constructor(private val windowX: Int, private 
         bg = image.getScaledInstance(windowX, windowY, Image.SCALE_SMOOTH)
 
         return this
+    }
+
+    fun setMouseCoordinateDisplayPosition(x: Int, y: Int) {
+        mouseCoordinateDisplayX = x
+        mouseCoordinateDisplayY = y
     }
 
     @JvmOverloads


### PR DESCRIPTION
Due to the placement of this year's elements, the mouse coordinate
display is not easily readable on top of the field image.

This contribution adds a function, `setMouseCoordinateDisplayPosition`,
which allows users to set a custom location on the field image to
display the mouse coordinates.

I've tested these changes with my code, and it works as expected, and I
didn't notice any issues.

To use the function, just call `setMouseCoordinateDisplayPosition` at
some point in your code before calling the `start()` function. Its x and
y parameters correspond to pixel locations relative to the top left
corner.